### PR TITLE
Fix clean-up buglet, and amend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Nonetheless, it works pretty well as a static blog generator. Pollen comes with 
 * Ideally you'll be on a system that can run Bash scripts and the GNU `make` utility
 * If you do use the included makefile to build the site, you will want to install [HTML5 Tidy](http://www.html-tidy.org) — or remove references to the `tidy` command in the makefile.
 
-Then just plop all the files from this repository in a folder.
+Next, just plop all the files from this repository in a folder.
+Move my `posts` directory out of the way to start writing your own content, e.g. `mv posts posts.example ; make spritz`
+Edit `feed.xml.pp`, filling in your own RSS metadata.
 
 ## Tinkering
 

--- a/about.html.pm
+++ b/about.html.pm
@@ -1,4 +1,4 @@
-#lang Pollen
+#lang pollen
 
 ◊(define-meta title "About The Notepad")
 

--- a/makefile
+++ b/makefile
@@ -117,8 +117,7 @@ spritz: ## Just cleans up LaTeX working folders and Pollen cache
 	rm -f notepad.sqlite; \
 	raco pollen reset
 
-zap: ## Does a spritz and also deletes all HTML and PDF output
-	rm -rf posts/pollen-latex-work pollen-latex-work; \
+zap: spritz ## Does a spritz and also deletes all HTML and PDF output
 	rm posts/*.html posts/*.pdf; \
 	rm feed.xml; \
 	rm *.html *.pdf; \

--- a/makefile
+++ b/makefile
@@ -114,6 +114,7 @@ publish: ## Rsync the website to the public web server (does not rebuild site fi
 # ‘make zap’ deletes all output files as well.
 spritz: ## Just cleans up LaTeX working folders and Pollen cache
 	rm -rf posts/pollen-latex-work pollen-latex-work; \
+	rm -f notepad.sqlite; \
 	raco pollen reset
 
 zap: ## Does a spritz and also deletes all HTML and PDF output


### PR DESCRIPTION
It was quite puzzling to me why `make zap` would still keep your posts. It took me a couple of minutes to find out about your SQlite caching mechanism, but others might not be so lucky or knowledgeable. I also noticed that zap didn't really depend on spritz, but rather duplicated its process, a source for future bugs.

Also amending the README to fill in some gaps, and fix the #lang casing in the About page source (it threw an error for me, probably due to changes in Racket 7).

Thanks for your awesome Pollen work.